### PR TITLE
Merge Host and Port columns into a single Host:Port column

### DIFF
--- a/cmd/sshproxyctl/sshproxyctl.go
+++ b/cmd/sshproxyctl/sshproxyctl.go
@@ -363,7 +363,6 @@ func showHosts(configFile string, csvFlag bool, jsonFlag bool) {
 	for i, h := range hosts {
 		rows[i] = []string{
 			h.Hostname,
-			h.Port,
 			h.State.String(),
 			h.Ts.Format("2006-01-02 15:04:05"),
 			fmt.Sprintf("%d", h.N),
@@ -375,7 +374,7 @@ func showHosts(configFile string, csvFlag bool, jsonFlag bool) {
 	if csvFlag {
 		displayCSV(rows)
 	} else {
-		displayTable([]string{"Host", "Port", "State", "Last check", "# of connections", "Bandwidth in", "Bandwidth out"}, rows)
+		displayTable([]string{"Host", "State", "Last check", "# of connections", "Bandwidth in", "Bandwidth out"}, rows)
 	}
 }
 

--- a/pkg/utils/etcd.go
+++ b/pkg/utils/etcd.go
@@ -18,7 +18,6 @@ import (
 	"encoding/pem"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"regexp"
 	"sort"
@@ -590,7 +589,6 @@ func (c *Client) GetUserConnectionsCount(username string) (int, error) {
 // FlatHost is a structure used to flatten a host informations present in etcd.
 type FlatHost struct {
 	Hostname string
-	Port     string
 	N        int
 	BwIn     int
 	BwOut    int
@@ -622,10 +620,7 @@ func (c *Client) GetUserHosts(key string) (map[string]*FlatHost, error) {
 			}
 			if hosts[fields[1]] == nil {
 				v := &FlatHost{}
-				v.Hostname, v.Port, err = net.SplitHostPort(fields[1])
-				if err != nil {
-					return nil, fmt.Errorf("splitting Host and Port from '%s': %v", fields[1], err)
-				}
+				v.Hostname = fields[1]
 				v.N = 1
 				v.BwIn = b.In
 				v.BwOut = b.Out
@@ -675,10 +670,7 @@ func (c *Client) GetAllHosts() ([]*FlatHost, error) {
 			return nil, fmt.Errorf("decoding JSON data at '%s': %v", ev.Key, err)
 		}
 		subkey := string(ev.Key)[len(etcdHostsPath)+1:]
-		v.Hostname, v.Port, err = net.SplitHostPort(subkey)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing key %s", subkey)
-		}
+		v.Hostname = subkey
 		if stats[subkey] == nil {
 			v.N = 0
 			v.BwIn = 0

--- a/pkg/utils/route.go
+++ b/pkg/utils/route.go
@@ -11,7 +11,6 @@
 package utils
 
 import (
-	"fmt"
 	"math/rand"
 	"net"
 	"sort"
@@ -108,7 +107,7 @@ func selectDestinationConnections(destinations []string, checker HostChecker, cl
 		}
 		userHostsc := map[string]int{}
 		for _, userHost := range userHosts {
-			userHostsc[fmt.Sprintf("%s:%s", userHost.Hostname, userHost.Port)] = userHost.N
+			userHostsc[userHost.Hostname] = userHost.N
 		}
 		hosts, err := cli.GetAllHosts()
 		if err != nil {
@@ -116,7 +115,7 @@ func selectDestinationConnections(destinations []string, checker HostChecker, cl
 		}
 		hostsc := map[string]int{}
 		for _, host := range hosts {
-			hostsc[fmt.Sprintf("%s:%s", host.Hostname, host.Port)] = host.N
+			hostsc[host.Hostname] = host.N
 		}
 		sort.Slice(destinations, func(i, j int) bool {
 			switch {
@@ -146,7 +145,7 @@ func selectDestinationBandwidth(destinations []string, checker HostChecker, cli 
 		}
 		userHostsbw := map[string]uint64{}
 		for _, userHost := range userHosts {
-			userHostsbw[fmt.Sprintf("%s:%s", userHost.Hostname, userHost.Port)] = (uint64(userHost.BwIn) * uint64(userHost.BwIn)) + (uint64(userHost.BwOut) * uint64(userHost.BwOut)) + uint64(userHost.N)
+			userHostsbw[userHost.Hostname] = (uint64(userHost.BwIn) * uint64(userHost.BwIn)) + (uint64(userHost.BwOut) * uint64(userHost.BwOut)) + uint64(userHost.N)
 		}
 		hosts, err := cli.GetAllHosts()
 		if err != nil {
@@ -154,7 +153,7 @@ func selectDestinationBandwidth(destinations []string, checker HostChecker, cli 
 		}
 		hostsbw := map[string]int{}
 		for _, host := range hosts {
-			hostsbw[fmt.Sprintf("%s:%s", host.Hostname, host.Port)] = (host.BwIn * host.BwIn) + (host.BwOut * host.BwOut) + host.N
+			hostsbw[host.Hostname] = (host.BwIn * host.BwIn) + (host.BwOut * host.BwOut) + host.N
 		}
 		sort.Slice(destinations, func(i, j int) bool {
 			switch {

--- a/test/centos-image/sshproxy_test.go
+++ b/test/centos-image/sshproxy_test.go
@@ -397,7 +397,7 @@ func TestStickyConnections(t *testing.T) {
 	time.Sleep(4 * time.Second)
 
 	disableHost("server1")
-	checkHostState(t, "server1", "disabled")
+	checkHostState(t, "server1:22", "disabled")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -410,7 +410,7 @@ func TestStickyConnections(t *testing.T) {
 
 	time.Sleep(time.Second)
 	enableHost("server1")
-	checkHostState(t, "server1", "up")
+	checkHostState(t, "server1:22", "up")
 
 	args, cmdStr := prepareCommand("gateway2", 2022, "hostname")
 	_, stdout, _, err := runCommand(ctx, "ssh", args, nil, nil)
@@ -429,7 +429,7 @@ func TestNotLongStickyConnections(t *testing.T) {
 	time.Sleep(4 * time.Second)
 
 	disableHost("server1")
-	checkHostState(t, "server1", "disabled")
+	checkHostState(t, "server1:22", "disabled")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -441,7 +441,7 @@ func TestNotLongStickyConnections(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 	enableHost("server1")
-	checkHostState(t, "server1", "up")
+	checkHostState(t, "server1:22", "up")
 
 	args, cmdStr := prepareCommand("gateway2", 2022, "hostname")
 	_, stdout, _, err := runCommand(ctx, "ssh", args, nil, nil)
@@ -460,7 +460,7 @@ func TestLongStickyConnections(t *testing.T) {
 
 	updateLineSSHProxyConf("etcd_keyttl", "10")
 	disableHost("server1")
-	checkHostState(t, "server1", "disabled")
+	checkHostState(t, "server1:22", "disabled")
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -472,7 +472,7 @@ func TestLongStickyConnections(t *testing.T) {
 
 	time.Sleep(2 * time.Second)
 	enableHost("server1")
-	checkHostState(t, "server1", "up")
+	checkHostState(t, "server1:22", "up")
 
 	args, cmdStr := prepareCommand("gateway2", 2022, "hostname")
 	_, stdout, _, err := runCommand(ctx, "ssh", args, nil, nil)
@@ -554,15 +554,15 @@ func checkHostCheck(t *testing.T, host string, check time.Time) time.Time {
 func TestEtcdHosts(t *testing.T) {
 	timeZero := time.Time{}
 
-	lastCheck := checkHostCheck(t, "server1", timeZero)
+	lastCheck := checkHostCheck(t, "server1:22", timeZero)
 
 	line := "check_interval: 5s"
 	addLineSSHProxyConf(line)
 	defer removeLineSSHProxyConf(line)
-	checkHostCheck(t, "server1", lastCheck)
+	checkHostCheck(t, "server1:22", lastCheck)
 
 	time.Sleep(5 * time.Second)
-	checkHostCheck(t, "server1", timeZero)
+	checkHostCheck(t, "server1:22", timeZero)
 }
 
 func checkHostState(t *testing.T, host, state string) {
@@ -597,7 +597,7 @@ func TestEnableDisableHost(t *testing.T) {
 	}
 
 	disableHost("server[1,100]")
-	checkHostState(t, "server1", "disabled")
+	checkHostState(t, "server1:22", "disabled")
 
 	_, stdout, _, err = runCommand(ctx, "ssh", args, nil, nil)
 	if err != nil {
@@ -609,7 +609,7 @@ func TestEnableDisableHost(t *testing.T) {
 	}
 
 	enableHost("server1")
-	checkHostState(t, "server1", "up")
+	checkHostState(t, "server1:22", "up")
 
 	// test stickyness
 	_, stdout, _, err = runCommand(ctx, "ssh", args, nil, nil)


### PR DESCRIPTION
`sshproxyctl` shows Host:Port everywhere, except in the `sshproxyctl show hosts` table. Let's streamline the use of Host:Port