### PR TITLE
revamp sshproxy.yaml with an all-new overrides system

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -2,7 +2,6 @@ task:
   env:
     GOPROXY: https://proxy.golang.org
     matrix:
-      VERSION: 1.20
       VERSION: 1.21
       VERSION: 1.22
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -31,7 +31,7 @@ be replayed with the +sshproxy-replay+ command.
 Compilation
 -----------
 
-Install the Go (version >= 1.20) compiler suite: see
+Install the Go (version >= 1.21) compiler suite: see
 http://golang.org/doc/install for details.
 
 Define and export the +$GOPATH+ directory where the source code will be

--- a/config/sshproxy.yaml
+++ b/config/sshproxy.yaml
@@ -160,24 +160,23 @@
 # this amount of time.
 #etcd_keyttl: 3600
 
-# Each option can be overridden for a specific source (IP address or DNS name
-# of the listening SSH daemon, with an optional port), for a specific user
-# and/or a Unix group of users (eg. for debugging purpose). Multiple source,
-# user and/or group can be defined. Each element of the "match" array is
-# treated as an "or" statement.  If an element of the "match" array contains
-# multiple keys, they are treated as an "and" statement. If multiple overrides
-# match the same user or group, they will be applied in the order they are
-# defined.  In the following example: alice, bob and any user in the group foo
-# will have the debug set to true. But if any of those are also in the groups
-# bar AND baz, debug will be set to false, as the last override takes
-# precedence.
+# Each option can be overridden for specific sources (IP address or DNS name of
+# the listening SSH daemon, with an optional port), for specific users and/or
+# Unix groups of users (eg. for debugging purpose). Multiple sources, users
+# and/or groups can be defined. Each element of the "match" array is treated as
+# an "or" statement.  If an element of the "match" array contains multiple
+# keys, they are treated as an "and" statement. If multiple overrides match,
+# they will be applied in the order they are defined. In the following example:
+# alice, bob and any user in the group foo will have the debug set to true. But
+# if any of those are also in the groups bar AND baz, debug will be set to
+# false, as the last override takes precedence.
 #overrides:
 #    - match:
-#        - source: 192.168.0.1
+#        - sources: [192.168.0.1]
 #      service: service1
 #      dest: [host1, host2]
 #    - match:
-#        - source: 192.168.0.2
+#        - sources: [192.168.0.2]
 #      service: service2
 #      dest: [host3, host4]
 #      route_select: bandwidth
@@ -188,9 +187,8 @@
 #      environment:
 #          XAUTHORITY: /dev/shm/.Xauthority_{user}
 #    - match:
-#        - user: alice
-#        - user: bob
-#        - group: foo
+#        - users: [alice, bob]
+#        - groups: [foo]
 #      debug: true
 #      log: /tmp/sshproxy-foo/{user}.log
 #      dump: /tmp/sshproxy-{user}-{time}.dump
@@ -203,6 +201,6 @@
 #          default:
 #              dest: [hostx]
 #    - match:
-#        - group: bar
-#          group: baz
+#        - groups: [bar]
+#          groups: [baz]
 #      debug: false

--- a/config/sshproxy.yaml
+++ b/config/sshproxy.yaml
@@ -106,7 +106,6 @@
 #    keyttl: 5
 #    mandatory: false
 
-# Environment.
 # Environment variables can be set if needed. The '{user}' pattern will be
 # replaced with the user login.
 #environment:
@@ -122,79 +121,88 @@
 # user. Default is 0.
 #max_connections_per_user: 0
 
-# Routes definition.
-# The key is the service name (only used for display). The special service name
-# "default" can be used to define a default route and does not need the source
-# key. The source value is the IP address or DNS name of the listening SSH
-# daemon (with an optional port). The dest value is an array of destination
-# hosts (with an optional port). The route_select value defines how the host
-# destination will be chosen. It can be "ordered" (the default), "random",
-# "connections" or "bandwidth". If "ordered", the hosts are tried in the order
-# listed until a successful connection is made. The list is first randomly
-# sorted if "random" is specified (i.e. a poor-man load-balancing algorithm).
-# If "connections", the hosts with less connections from the user have
-# priority, then the hosts with less global connections, and in case of a draw,
-# the selection is random. For "bandwidth", it's the same as "connections", but
-# based on the bandwidth used, with a rollback on connections (which is
-# frequent for new simultaneous connections). The mode value defines the
-# stickiness of a connection. It can be "sticky" or "balanced" (defaults to
-# sticky). If "sticky", then all connections of a user will be made on the same
-# destination host. If "balanced", the route_select algorithm will be used for
-# every connection.  Finally, the force_command can be set to override the
-# command asked by the user. If command_must_match is set to true, then the
-# connection is closed if the original command is not the same as the
-# force_command. command_must_match defaults to false. etcd_keyttl defauts to
+# The service name is used for display. It's also used as a key in order to
+# check in etcd if a user already has active connections. The default service
+# name is "default".
+#service: default
+
+# The dest value is an array of destination hosts (with an optional port).
+#dest: [host5:4222]
+
+# The route_select value defines how the host destination will be chosen. It
+# can be "ordered" (the default), "random", "connections" or "bandwidth". If
+# "ordered", the hosts are tried in the order listed until a successful
+# connection is made. The list is first randomly sorted if "random" is
+# specified (i.e. a poor-man load-balancing algorithm).  If "connections", the
+# hosts with less connections from the user have priority, then the hosts with
+# less global connections, and in case of a draw, the selection is random. For
+# "bandwidth", it's the same as "connections", but based on the bandwidth used,
+# with a rollback on connections (which is frequent for new simultaneous
+# connections).
+#route_select: ordered
+
+# The mode value defines the stickiness of a connection. It can be "sticky" or
+# "balanced" (defaults to sticky). If "sticky", then all connections of a user
+# will be made on the same destination host. If "balanced", the route_select
+# algorithm will be used for every connection.
+#mode: sticky
+
+# The force_command can be set to override the command asked by the user.
+#force_command: "internal-sftp"
+
+# If command_must_match is set to true, then the connection is closed if the
+# original command is not the same as the force_command. command_must_match
+# defaults to false.
+#command_must_match: false
+
+# etcd_keyttl defauts to
 # 0. If a value is set (in seconds), the chosen backend will be remembered for
-# this amount of time. Environment variables can be set if needed. The '{user}'
-# pattern will be replaced with the user login.
-#routes:
-#    service1:
-#        source: ["192.168.0.1"]
-#        dest: [host1, host2]
-#    service2:
-#        source: ["192.168.0.2"]
-#        dest: [host3, host4]
-#        route_select: bandwidth
-#        mode: balanced
-#        force_command: "internal-sftp"
-#        command_must_match: true
-#        etcd_keyttl: 3600
-#        environment:
-#            XAUTHORITY: /dev/shm/.Xauthority_{user}
-#    default:
-#        dest: ["host5:4222"]
+# this amount of time.
+#etcd_keyttl: 3600
 
-# Each option can be overridden for a Unix group of users. Multiple groups can
-# be defined on the same line, separated by commas.
-# If a user is in multiple groups and these groups are defined in the
-# configuration, the configuration of a previous group will be overridden by the
-# next ones.
-# The parameters defined in a "users" option (see below) will be applied last
-# and override groups parameters.
-#groups:
-#    - foo,bar:
-#        debug: true
-#        log: /tmp/sshproxy-foo/{user}.log
-#        # An associative array is used to specify environment, SSH options or
-#        # routes.
-#        environment:
-#            ENV1: /tmp/env
-#        ssh:
-#            args: ["-vvv", "-Y"]
-#        # If routes are specified, they are fully overridden, not merged.
-#        routes:
-#            default:
-#                dest: [hostx]
-
-# Each option can also be overridden for a specific user (eg. for debugging
-# purpose). Multiple users can be defined on the same line, separated by
-# commas.
-#users:
-#    - foo,bar:
-#        debug: true
-#        log: /tmp/sshproxy-{user}.log
-#        dump: /tmp/sshproxy-{user}-{time}.dump
-#        # An associative array is used to specify environment, SSH options or
-#        # routes.
-#        ssh:
-#            args: ["-vvv", "-Y"]
+# Each option can be overridden for a specific source (IP address or DNS name
+# of the listening SSH daemon, with an optional port), for a specific user
+# and/or a Unix group of users (eg. for debugging purpose). Multiple source,
+# user and/or group can be defined. Each element of the "match" array is
+# treated as an "or" statement.  If an element of the "match" array contains
+# multiple keys, they are treated as an "and" statement. If multiple overrides
+# match the same user or group, they will be applied in the order they are
+# defined.  In the following example: alice, bob and any user in the group foo
+# will have the debug set to true. But if any of those are also in the groups
+# bar AND baz, debug will be set to false, as the last override takes
+# precedence.
+#overrides:
+#    - match:
+#        - source: 192.168.0.1
+#      service: service1
+#      dest: [host1, host2]
+#    - match:
+#        - source: 192.168.0.2
+#      service: service2
+#      dest: [host3, host4]
+#      route_select: bandwidth
+#      mode: balanced
+#      force_command: "internal-sftp"
+#      command_must_match: true
+#      etcd_keyttl: 3600
+#      environment:
+#          XAUTHORITY: /dev/shm/.Xauthority_{user}
+#    - match:
+#        - user: alice
+#        - user: bob
+#        - group: foo
+#      debug: true
+#      log: /tmp/sshproxy-foo/{user}.log
+#      dump: /tmp/sshproxy-{user}-{time}.dump
+#      environment:
+#          ENV1: /tmp/env
+#      ssh:
+#          args: ["-vvv", "-Y"]
+#      # If routes are specified, each specified route is fully overridden, not merged.
+#      routes:
+#          default:
+#              dest: [hostx]
+#    - match:
+#        - group: bar
+#          group: baz
+#      debug: false

--- a/doc/sshproxy.yaml.txt
+++ b/doc/sshproxy.yaml.txt
@@ -219,11 +219,6 @@ The pattern '\{user}' will be replaced with the user login:
 	an integer. Defauts to 0. If a value is set (in seconds), the chosen
 	backend will be remembered for this amount of time.
 
-In the previous example, a client connected to '192.168.0.1' will be proxied
-to 'host1' and, if the host is not reachable, to 'host2'. If a client does not
-connect to '192.168.0.1' or '192.168.0.2' it will be proxied to the sshd
-daemon listening on port 4222 on 'host5'.
-
 Each of the previous parameters can be overridden for specific source (IP
 address or DNS name of the listening SSH daemon, with an optional port), for a
 specific user or a group thanks to the *overrides* associative array.

--- a/doc/sshproxy.yaml.txt
+++ b/doc/sshproxy.yaml.txt
@@ -219,26 +219,26 @@ The pattern '\{user}' will be replaced with the user login:
 	an integer. Defauts to 0. If a value is set (in seconds), the chosen
 	backend will be remembered for this amount of time.
 
-Each of the previous parameters can be overridden for specific source (IP
-address or DNS name of the listening SSH daemon, with an optional port), for a
-specific user or a group thanks to the *overrides* associative array.
+Each of the previous parameters can be overridden for specific sources (IP
+address or DNS name of the listening SSH daemon, with an optional port), for
+specific users or groups thanks to the *overrides* associative array.
 
 For example if we want to save debug messages for the 'foo' group we define:
 
 	overrides:
 	    - match:
-	        - group: foo
+	        - groups: [foo]
 	      debug: true
 
-It is possible to override the same options for multiple groups.
+It is possible to override the same options for multiple groups and users.
 
-For example, if we want to save debug messages for both the 'foo' and 'bar'
-groups we define:
+For example, if we want to save debug messages if the user is 'alice' or if
+its groups contain 'foo' or 'bar' groups we define:
 
 	overrides:
 	    - match:
-	        - group: foo
-	        - group: bar
+	        - users: [alice]
+	        - groups: [foo, bar]
 	      debug: true
 
 Any key can be defined (in this example, the keys are overriden if the user is
@@ -246,8 +246,8 @@ Any key can be defined (in this example, the keys are overriden if the user is
 
 	overrides:
 	    - match:
-	        - user: alice
-	          source: 192.168.0.1:22
+	        - users: [alice]
+	          sources: [192.168.0.1:22]
 	      service: default
 	      dest: [hostx]
 	      ssh:
@@ -263,10 +263,10 @@ in '/var/log/sshproxy/admin/\{user}.log' with the following configuration:
 
 	overrides:
 	    - match:
-	        - group: users
+	        - groups: [users]
 	      log: /var/log/sshproxy/users/{user}.log
 	    - match:
-	        - group: admin
+	        - groups: [admin]
 	      log: /var/log/sshproxy/admin/{user}.log
 
 Each element of the *match* array is treated as an "or" statement. If an
@@ -303,16 +303,15 @@ route_select: random
 
 overrides:
     - match:
-        - user: alice
-        - user: bob
-        - group: foo
+        - users: [alice, bob]
+        - groups: [foo]
       service: default
       dest: [login0]
       debug: true
       dump: /var/spool/sshproxy/{user}-{time}-{sid}.dump
     - match:
-        - group: bar
-          group: baz
+        - groups: [bar]
+          groups: [baz]
       debug: false
 ------------------------------------------------------------------------------
 

--- a/doc/sshproxy.yaml.txt
+++ b/doc/sshproxy.yaml.txt
@@ -178,85 +178,85 @@ The pattern '\{user}' will be replaced with the user login:
 	environment:
 	    XAUTHORITY: /tmp/.Xauthority_{user}
 
-An associative array *routes* defines the destination according to the
-listening IP address of the SSH daemon:
+*service*::
+	a string. Used for display. It's also used as a key in order to check
+	in etcd if a user already has active connections. Defaults to
+	'default'.
 
-	routes:
-	    service1:
-	        source: ["192.168.0.1"]
-	        dest: [host1, host2]
-	    service2:
-	        source: ["192.168.0.2"]
-	        dest: [host3, host4]
-	        route_select: bandwidth
-	        mode: balanced
-		force_command: "internal-sftp"
-		command_must_match: true
-		etcd_keyttl: 3600
-		environment:
-		    XAUTHORITY: /dev/shm/.Xauthority_{user}
-	    default:
-	        dest: ["host5:4222"]
+*dest*::
+	an array of destination hosts (with an optional port).
 
-The key is the service name (only used for display). The special service name
-'default' can be used to define a default route and does not need the source
-key. The source value is the IP address or DNS name of the listening SSH
-daemon (with an optional port). The dest value is an array of destination
-hosts (with an optional port). The route_select value difines how the host
-destination will be chosen. It can be 'ordered' (the default), 'random',
-'connections' or 'bandwidth'. If 'ordered', the hosts are tried in the order
-listed until a successful connection is made. The list is first randomly
-sorted if 'random' is specified (i.e. a poor-man load-balancing algorithm).
-If 'connections', the hosts with less connections from the user have
-priority, then the hosts with less global connections, and in case of a draw,
-the selection is random. For 'bandwidth', it's the same as 'connections', but
-based on the bandwidth used, with a rollback on connections (which is
-frequent for new simultaneous connections). The mode value defines the
-stickiness of a connection. It can be 'sticky' or 'balanced' (defaults to
-'sticky'). If 'sticky', then all connections of a user will be made on the
-same destination host. If 'balanced', the route_select algorithm will be used
-for every connections.  Finally, the force_command can be set to override the
-command asked by the user. If command_must_match is set to true, then the
-connection is closed if the original command is not the same as the
-force_command. command_must_match defaults to false. etcd_keyttl defauts to 0.
-If a value is set (in seconds), the chosen backend will be remembered for this
-amount of time. An associative array *environment* can be used to set
-environment variables. The pattern '\{user}' will be replaced with the user
-login.
+	dest: [host5:4222]
+
+*route_select*::
+	a string. Defines how the host destination will be chosen. It can be
+	'ordered' (the default), 'random', 'connections' or 'bandwidth'. If
+	'ordered', the hosts are tried in the order listed until a successful
+	connection is made.  The list is first randomly sorted if 'random' is
+	specified (i.e. a poor-man load-balancing algorithm).  If
+	'connections', the hosts with less connections from the user have
+	priority, then the hosts with less global connections, and in case of
+	a draw, the selection is random. For 'bandwidth', it's the same as
+	'connections', but based on the bandwidth used, with a rollback on
+	connections (which is frequent for new simultaneous connections).
+
+*mode*::
+	a string. Defines the stickiness of a connection. It can be 'sticky'
+	or 'balanced' (defaults to 'sticky'). If 'sticky', then all
+	connections of a user will be made on the same destination host. If
+	'balanced', the route_select algorithm will be used for every
+	connection.
+
+*The force_command*::
+	a string. Can be set to override the command asked by the user.
+
+*command_must_match*::
+	a boolean. If set to 'true', then the connection is closed if the
+	original command is not the same as the force_command. Defaults to
+	'false'.
+
+*etcd_keyttl*::
+	an integer. Defauts to 0. If a value is set (in seconds), the chosen
+	backend will be remembered for this amount of time.
 
 In the previous example, a client connected to '192.168.0.1' will be proxied
 to 'host1' and, if the host is not reachable, to 'host2'. If a client does not
 connect to '192.168.0.1' or '192.168.0.2' it will be proxied to the sshd
 daemon listening on port 4222 on 'host5'.
 
-Each of the previous parameters can be overridden for a group thanks to the
-*groups* associative array.
+Each of the previous parameters can be overridden for specific source (IP
+address or DNS name of the listening SSH daemon, with an optional port), for a
+specific user or a group thanks to the *overrides* associative array.
 
 For example if we want to save debug messages for the 'foo' group we define:
 
-	groups:
-	    - foo:
-	        debug: true
+	overrides:
+	    - match:
+	        - group: foo
+	      debug: true
 
-It is possible to override the same options for multiple groups in a single
-line, with comma-separated groups.
+It is possible to override the same options for multiple groups.
 
-For example, if we want to save debug messages for the 'foo' and 'bar' groups
-we define:
+For example, if we want to save debug messages for both the 'foo' and 'bar'
+groups we define:
 
-	groups:
-	    - foo,bar:
-	        debug: true
+	overrides:
+	    - match:
+	        - group: foo
+	        - group: bar
+	      debug: true
 
-Routes, environment or SSH options can also be defined:
+Any key can be defined (in this example, the keys are overriden if the user is
+'alice' AND if the source is '192.168.0.1:22'):
 
-	groups:
-	    - foo:
-	        routes:
-	            default:
-	                dest: [hostx]
-	        ssh:
-	            args: ["-vvv", "-Y"]
+	overrides:
+	    - match:
+	        - user: alice
+	          source: 192.168.0.1:22
+	      service: default
+	      dest: [hostx]
+	      ssh:
+	          args: ["-vvv", "-Y"]
 
 The routes are merged with previous defined ones.
 
@@ -266,32 +266,22 @@ configuration file, each setting can be overridden by the next group.
 For example, if a user is in the 'admin' and 'users' groups the logs will be
 in '/var/log/sshproxy/admin/\{user}.log' with the following configuration:
 
-	groups:
-	    - users:
-	        log: /var/log/sshproxy/users/{user}.log
-	    - admin:
-	        log: /var/log/sshproxy/admin/{user}.log
+	overrides:
+	    - match:
+	        - group: users
+	      log: /var/log/sshproxy/users/{user}.log
+	    - match:
+	        - group: admin
+	      log: /var/log/sshproxy/admin/{user}.log
 
-We can also override the parameters for a specific user with the 'users'
-associative array. We can also override the parameters for multiple users in a
-single line, with comma-separated users.
+Each element of the *match* array is treated as an "or" statement. If an
+element of the *match* array contains multiple keys, they are treated as an
+"and" statement.
 
-For example if we want to save debug messages for the 'foo' and the 'bar'
-users we define:
-
-	users:
-	    - foo,bar:
-	        debug: true
-
-As for the groups, we can modify routes, environment or SSH options:
-
-	users:
-	    - foo:
-	        ssh:
-	            args: ["-vvv", "-Y"]
-
-The parameters defined for a user are the last applied and therefore always
-override the settings defined by in the 'groups' associative array.
+In the following example: 'alice', 'bob' and any user in the group 'foo' will
+have the 'debug' set to true. But if any of those are also in the groups 'bar'
+AND 'baz', 'debug' will be set to false, as the last override takes
+precedence.
 
 EXAMPLE
 -------
@@ -312,21 +302,23 @@ environment:
 ssh:
     args: ["-q", "-Y", "-enone"]
 
-routes:
-    default:
-        dest: [login1, login2]
-        route_select: random
+service: default
+dest: [login1, login2]
+route_select: random
 
-groups:
-    - admin:
-        routes:
-            default:
-                dest: [login0]
-
-users:
-    - user1234:
-        debug: true
-        dump: /var/spool/sshproxy/{user}-{time}-{sid}.dump
+overrides:
+    - match:
+        - user: alice
+        - user: bob
+        - group: foo
+      service: default
+      dest: [login0]
+      debug: true
+      dump: /var/spool/sshproxy/{user}-{time}-{sid}.dump
+    - match:
+        - group: bar
+          group: baz
+      debug: false
 ------------------------------------------------------------------------------
 
 FILES

--- a/doc/sshproxyctl.txt
+++ b/doc/sshproxyctl.txt
@@ -83,11 +83,13 @@ COMMANDS
 *show error_banner*::
 	Show error banners stored in etcd and in configuration.
 
-*get_config [-user USER] [-groups GROUPS]*::
+*show [-user USER] [-groups GROUPS] [-source SOURCE] config*::
 	Display the calculated configuration. If a user is given, its system
 	groups (if any) are added to the given groups. If a user and/or groups
 	are given with '-user' and '-groups' options, the configuration will
-	be calculated for these specific user/groups.
+	be calculated for these specific user/groups. If a source
+	(host[:port]) is given with the '-source' option, the configuration
+	will be calculated for this specific source.
 
 
 FILES

--- a/misc/sshproxyctl-completion.bash
+++ b/misc/sshproxyctl-completion.bash
@@ -5,7 +5,7 @@ _sshproxyctl() {
         COMPREPLY=()
         cur="${COMP_WORDS[COMP_CWORD]}"
         prev="${COMP_WORDS[COMP_CWORD-1]}"
-        commands="disable enable error_banner forget get_config help show version"
+        commands="disable enable error_banner forget help show version"
         opts="-h -c ${commands}"
 
         case "${prev}" in
@@ -13,7 +13,7 @@ _sshproxyctl() {
                 COMPREPLY=( $(compgen -W "${commands}" -- "${cur}") )
                 ;;
             show)
-                COMPREPLY=( $(compgen -W '-all -csv -json connections hosts users groups error_banner' -- "${cur}") )
+                COMPREPLY=( $(compgen -W '-all -csv -json -user -groups -source connections hosts users groups error_banner config' -- "${cur}") )
                 ;;
             connections)
                 COMPREPLY=( $(compgen -W '-all -csv -json' -- "${cur}") )
@@ -27,11 +27,11 @@ _sshproxyctl() {
             groups)
                 COMPREPLY=( $(compgen -W '-all -csv -json' -- "${cur}") )
                 ;;
+            config)
+                COMPREPLY=( $(compgen -W '-user -groups -source' -- "${cur}") )
+                ;;
             error_banner)
                 COMPREPLY=( $(compgen -W '-expire' -- "${cur}") )
-                ;;
-            get_config)
-                COMPREPLY=( $(compgen -W '-user -groups' -- "${cur}") )
                 ;;
             -all)
                 COMPREPLY=( $(compgen -W '-csv -json connections users groups' -- "${cur}") )
@@ -41,6 +41,15 @@ _sshproxyctl() {
                 ;;
             -json)
                 COMPREPLY=( $(compgen -W '-all connections hosts users groups' -- "${cur}") )
+                ;;
+            -user)
+                COMPREPLY=( $(compgen -W '-groups -source config' -- "${cur}") )
+                ;;
+            -groups)
+                COMPREPLY=( $(compgen -W '-user -source config' -- "${cur}") )
+                ;;
+            -source)
+                COMPREPLY=( $(compgen -W '-user -groups config' -- "${cur}") )
                 ;;
             -c)
                 _filedir

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -12,9 +12,9 @@ package utils
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"regexp"
-	"strings"
 	"time"
 
 	"gopkg.in/yaml.v2"
@@ -23,8 +23,14 @@ import (
 var (
 	defaultSSHExe  = "ssh"
 	defaultSSHArgs = []string{"-q", "-Y"}
-	defaultRoutes  = map[string]*RouteConfig{"default": &RouteConfig{
-		Dest: []string{}}}
+	// defaultAlgorithm is the default algorithm used to find a route if no
+	// other algorithm is specified in configuration.
+	defaultAlgorithm = "ordered"
+	// defaultMode is the default mode used to find a route if no other mode is
+	// specified in the configuration.
+	defaultMode    = "sticky"
+	defaultService = "default"
+	defaultDest    = []string{}
 )
 
 // Config represents the configuration for sshproxy.
@@ -43,10 +49,15 @@ type Config struct {
 	SSH                   sshConfig
 	TranslateCommands     map[string]*TranslateCommandConfig `yaml:"translate_commands"`
 	Environment           map[string]string
-	Routes                map[string]*RouteConfig
-	MaxConnectionsPerUser int `yaml:"max_connections_per_user"`
-	Users                 []map[string]subConfig
-	Groups                []map[string]subConfig
+	Service               string
+	Dest                  []string
+	RouteSelect           string `yaml:"route_select"`
+	Mode                  string
+	ForceCommand          string `yaml:"force_command"`
+	CommandMustMatch      bool   `yaml:"command_must_match"`
+	EtcdKeyTTL            int64  `yaml:"etcd_keyttl"`
+	MaxConnectionsPerUser int    `yaml:"max_connections_per_user"`
+	Overrides             []subConfig
 }
 
 // TranslateCommandConfig represents the configuration of a translate_command.
@@ -55,21 +66,6 @@ type TranslateCommandConfig struct {
 	SSHArgs     []string `yaml:"ssh_args"`
 	Command     string
 	DisableDump bool `yaml:"disable_dump"`
-}
-
-// RouteConfig represents the configuration of a route. Dest is mandatory,
-// Source is mandatory if the associated service name is not the default one.
-// RouteSelect defaults to "ordered", Mode defaults to "stiky", ForceCommand is
-// optional, CommandMustMatch defaults to false
-type RouteConfig struct {
-	Source           []string
-	Dest             []string
-	RouteSelect      string `yaml:"route_select"`
-	Mode             string
-	ForceCommand     string `yaml:"force_command"`
-	CommandMustMatch bool   `yaml:"command_must_match"`
-	EtcdKeyTTL       int64  `yaml:"etcd_keyttl"`
-	Environment      map[string]string
 }
 
 type sshConfig struct {
@@ -95,20 +91,29 @@ type etcdTLSConfig struct {
 // We use interface{} instead of real type to check if the option was specified
 // or not.
 type subConfig struct {
+	Match                 []map[string]string
 	Debug                 interface{}
 	Log                   interface{}
+	CheckInterval         interface{} `yaml:"check_interval"`
 	ErrorBanner           interface{} `yaml:"error_banner"`
 	Dump                  interface{}
-	DumpLimitSize         interface{}                        `yaml:"dump_limit_size"`
-	DumpLimitWindow       interface{}                        `yaml:"dump_limit_window"`
-	EtcdStatsInterval     interface{}                        `yaml:"etcd_stats_interval"`
-	LogStatsInterval      interface{}                        `yaml:"log_stats_interval"`
-	BgCommand             interface{}                        `yaml:"bg_command"`
+	DumpLimitSize         interface{} `yaml:"dump_limit_size"`
+	DumpLimitWindow       interface{} `yaml:"dump_limit_window"`
+	Etcd                  interface{}
+	EtcdStatsInterval     interface{} `yaml:"etcd_stats_interval"`
+	LogStatsInterval      interface{} `yaml:"log_stats_interval"`
+	BgCommand             interface{} `yaml:"bg_command"`
+	SSH                   interface{}
 	TranslateCommands     map[string]*TranslateCommandConfig `yaml:"translate_commands"`
 	Environment           map[string]string
-	Routes                map[string]*RouteConfig
+	Service               interface{}
+	Dest                  []string
+	RouteSelect           interface{} `yaml:"route_select"`
+	Mode                  interface{}
+	ForceCommand          interface{} `yaml:"force_command"`
+	CommandMustMatch      interface{} `yaml:"command_must_match"`
+	EtcdKeyTTL            interface{} `yaml:"etcd_keyttl"`
 	MaxConnectionsPerUser interface{} `yaml:"max_connections_per_user"`
-	SSH                   sshConfig
 }
 
 // Return slice of strings containing formatted configuration values
@@ -121,20 +126,23 @@ func PrintConfig(config *Config, groups map[string]bool) []string {
 	output = append(output, fmt.Sprintf("config.dump = %s", config.Dump))
 	output = append(output, fmt.Sprintf("config.dump_limit_size = %d", config.DumpLimitSize))
 	output = append(output, fmt.Sprintf("config.dump_limit_window = %s", config.DumpLimitWindow.Duration()))
+	output = append(output, fmt.Sprintf("config.etcd = %+v", config.Etcd))
 	output = append(output, fmt.Sprintf("config.etcd_stats_interval = %s", config.EtcdStatsInterval.Duration()))
 	output = append(output, fmt.Sprintf("config.log_stats_interval = %s", config.LogStatsInterval.Duration()))
-	output = append(output, fmt.Sprintf("config.etcd = %+v", config.Etcd))
 	output = append(output, fmt.Sprintf("config.bg_command = %s", config.BgCommand))
+	output = append(output, fmt.Sprintf("config.ssh = %+v", config.SSH))
 	for k, v := range config.TranslateCommands {
 		output = append(output, fmt.Sprintf("config.TranslateCommands.%s = %+v", k, v))
 	}
 	output = append(output, fmt.Sprintf("config.environment = %v", config.Environment))
-	for k, v := range config.Routes {
-		output = append(output, fmt.Sprintf("config.routes.%s = %+v", k, v))
-	}
+	output = append(output, fmt.Sprintf("config.service = %s", config.Service))
+	output = append(output, fmt.Sprintf("config.dest = %v", config.Dest))
+	output = append(output, fmt.Sprintf("config.route_select = %s", config.RouteSelect))
+	output = append(output, fmt.Sprintf("config.mode = %s", config.Mode))
+	output = append(output, fmt.Sprintf("config.force_command = %s", config.ForceCommand))
+	output = append(output, fmt.Sprintf("config.command_must_match = %v", config.CommandMustMatch))
+	output = append(output, fmt.Sprintf("config.etcd_keyttl = %d", config.EtcdKeyTTL))
 	output = append(output, fmt.Sprintf("config.max_connections_per_user = %d", config.MaxConnectionsPerUser))
-	output = append(output, fmt.Sprintf("config.ssh.exe = %s", config.SSH.Exe))
-	output = append(output, fmt.Sprintf("config.ssh.args = %v", config.SSH.Args))
 	return output
 }
 
@@ -147,6 +155,14 @@ func parseSubConfig(config *Config, subconfig *subConfig) error {
 		config.Log = subconfig.Log.(string)
 	}
 
+	if subconfig.CheckInterval != nil {
+		var err error
+		config.CheckInterval, err = ParseDuration(subconfig.CheckInterval.(string))
+		if err != nil {
+			return err
+		}
+	}
+
 	if subconfig.ErrorBanner != nil {
 		config.ErrorBanner = subconfig.ErrorBanner.(string)
 	}
@@ -156,7 +172,7 @@ func parseSubConfig(config *Config, subconfig *subConfig) error {
 	}
 
 	if subconfig.DumpLimitSize != nil {
-		config.DumpLimitSize = subconfig.DumpLimitSize.(uint64)
+		config.DumpLimitSize = uint64(subconfig.DumpLimitSize.(int))
 	}
 
 	if subconfig.DumpLimitWindow != nil {
@@ -165,6 +181,10 @@ func parseSubConfig(config *Config, subconfig *subConfig) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if subconfig.Etcd != nil {
+		config.Etcd = subconfig.Etcd.(etcdConfig)
 	}
 
 	if subconfig.EtcdStatsInterval != nil {
@@ -187,24 +207,8 @@ func parseSubConfig(config *Config, subconfig *subConfig) error {
 		config.BgCommand = subconfig.BgCommand.(string)
 	}
 
-	if subconfig.SSH.Exe != "" {
-		config.SSH.Exe = subconfig.SSH.Exe
-	}
-
-	if subconfig.SSH.Args != nil {
-		config.SSH.Args = subconfig.SSH.Args
-	}
-
-	// merge routes
-	if config.Routes == nil {
-		config.Routes = defaultRoutes
-	}
-	for service, opts := range subconfig.Routes {
-		config.Routes[service] = opts
-	}
-
-	if subconfig.MaxConnectionsPerUser != nil {
-		config.MaxConnectionsPerUser = subconfig.MaxConnectionsPerUser.(int)
+	if subconfig.SSH != nil {
+		config.SSH = subconfig.SSH.(sshConfig)
 	}
 
 	// merge translate_commands
@@ -215,6 +219,38 @@ func parseSubConfig(config *Config, subconfig *subConfig) error {
 	// merge environment
 	for k, v := range subconfig.Environment {
 		config.Environment[k] = v
+	}
+
+	if subconfig.Service != nil {
+		config.Service = subconfig.Service.(string)
+	}
+
+	if len(subconfig.Dest) > 0 {
+		config.Dest = subconfig.Dest
+	}
+
+	if subconfig.RouteSelect != nil {
+		config.RouteSelect = subconfig.RouteSelect.(string)
+	}
+
+	if subconfig.Mode != nil {
+		config.Mode = subconfig.Mode.(string)
+	}
+
+	if subconfig.ForceCommand != nil {
+		config.ForceCommand = subconfig.ForceCommand.(string)
+	}
+
+	if subconfig.CommandMustMatch != nil {
+		config.CommandMustMatch = subconfig.CommandMustMatch.(bool)
+	}
+
+	if subconfig.EtcdKeyTTL != nil {
+		config.EtcdKeyTTL = int64(subconfig.EtcdKeyTTL.(int))
+	}
+
+	if subconfig.MaxConnectionsPerUser != nil {
+		config.MaxConnectionsPerUser = subconfig.MaxConnectionsPerUser.(int)
 	}
 
 	return nil
@@ -229,8 +265,8 @@ func replace(src string, replacer *patternReplacer) string {
 	return replacer.Regexp.ReplaceAllString(src, replacer.Text)
 }
 
-// LoadConfig load configuration file and adapt it according to specified user.
-func LoadConfig(filename, currentUsername, sid string, start time.Time, groups map[string]bool) (*Config, error) {
+// LoadConfig load configuration file and adapt it according to specified user/group/sshdHostPort.
+func LoadConfig(filename, currentUsername, sid string, start time.Time, groups map[string]bool, sshdHostPort string) (*Config, error) {
 	patterns := map[string]*patternReplacer{
 		"{user}": {regexp.MustCompile(`{user}`), currentUsername},
 		"{sid}":  {regexp.MustCompile(`{sid}`), sid},
@@ -250,6 +286,51 @@ func LoadConfig(filename, currentUsername, sid string, start time.Time, groups m
 		return nil, err
 	}
 
+	for _, override := range config.Overrides {
+		for _, conditions := range override.Match {
+			match := true
+			for cType, cValue := range conditions {
+				// other cType can be defined as needed. For example
+				// environment variables could be useful matches
+				if cType == "user" && cValue != currentUsername {
+					match = false
+				} else if cType == "group" && !groups[cValue] {
+					match = false
+				} else if cType == "source" {
+					if sshdHostPort == "" {
+						match = false
+					} else {
+						match, err = MatchSource(cValue, sshdHostPort)
+						if err != nil {
+							return nil, err
+						}
+					}
+				}
+				if !match {
+					// no need to go further as match is false and we're in an
+					// "and" statement
+					break
+				}
+			}
+			if match {
+				// apply the override because we're in an "or" statement
+				if err := parseSubConfig(&config, &override); err != nil {
+					return nil, err
+				}
+				// no need to to parse the same subconfig twice
+				break
+			}
+		}
+	}
+
+	if config.Service == "" {
+		config.Service = defaultService
+	}
+
+	if config.Dest == nil {
+		config.Dest = defaultDest
+	}
+
 	if config.SSH.Exe == "" {
 		config.SSH.Exe = defaultSSHExe
 	}
@@ -258,34 +339,20 @@ func LoadConfig(filename, currentUsername, sid string, start time.Time, groups m
 		config.SSH.Args = defaultSSHArgs
 	}
 
-	// we have to use a slice of maps in order to have ordered maps
-	for _, groupconfigs := range config.Groups {
-		for groupnames, groupconfig := range groupconfigs {
-			for _, groupname := range strings.Split(groupnames, ",") {
-				if groups[groupname] {
-					if err := parseSubConfig(&config, &groupconfig); err != nil {
-						return nil, err
-					}
-					// no need to to parse the same subconfig twice
-					break
-				}
-			}
-		}
+	if config.RouteSelect == "" {
+		config.RouteSelect = defaultAlgorithm
 	}
 
-	// we have to use a slice of maps in order to have ordered maps
-	for _, userconfigs := range config.Users {
-		for usernames, userconfig := range userconfigs {
-			for _, username := range strings.Split(usernames, ",") {
-				if username == currentUsername {
-					if err := parseSubConfig(&config, &userconfig); err != nil {
-						return nil, err
-					}
-					// no need to to parse the same subconfig twice
-					break
-				}
-			}
-		}
+	if !IsRouteAlgorithm(config.RouteSelect) {
+		return nil, fmt.Errorf("invalid value for `route_select` option of service '%s': %s", config.Service, config.RouteSelect)
+	}
+
+	if config.Mode == "" {
+		config.Mode = defaultMode
+	}
+
+	if !IsRouteMode(config.Mode) {
+		return nil, fmt.Errorf("invalid value for `mode` option of service '%s': %s", config.Service, config.Mode)
 	}
 
 	if config.Log != "" {
@@ -296,15 +363,17 @@ func LoadConfig(filename, currentUsername, sid string, start time.Time, groups m
 		config.Environment[k] = replace(v, patterns["{user}"])
 	}
 
-	for service, opts := range config.Routes {
-		for k, v := range opts.Environment {
-			config.Routes[service].Environment[k] = replace(v, patterns["{user}"])
-		}
+	if len(config.Dest) == 0 {
+		return nil, fmt.Errorf("no destination defined for service '%s'", config.Service)
 	}
 
-	// replace sources and destinations (with possible missing port) with host:port.
-	if err := CheckRoutes(config.Routes); err != nil {
-		return nil, fmt.Errorf("invalid value in `routes` option: %s", err)
+	// replace destinations (with possible missing port) with host:port
+	for i, dst := range config.Dest {
+		host, port, err := SplitHostPort(dst)
+		if err != nil {
+			return nil, fmt.Errorf("invalid destination '%s' for service '%s': %s", dst, config.Service, err)
+		}
+		config.Dest[i] = net.JoinHostPort(host, port)
 	}
 
 	if config.Dump != "" {

--- a/pkg/utils/route.go
+++ b/pkg/utils/route.go
@@ -23,18 +23,6 @@ var mylog = logging.MustGetLogger("sshproxy")
 
 type selectDestinationFunc func([]string, HostChecker, *Client, string) (string, error)
 
-var (
-	// DefaultAlgorithm is the default algorithm used to find a route if no
-	// other algorithm is specified in configuration.
-	DefaultAlgorithm = "ordered"
-	// DefaultMode is the default mode used to find a route if no other mode is
-	// specified in the configuration.
-	DefaultMode = "sticky"
-	// DefaultRouteKeyword is the keyword used to specify the default
-	// route.
-	DefaultRouteKeyword = "default:22"
-)
-
 // HostChecker is the interface that wraps the Check method.
 //
 // Check tests if a connection to host:port can be made.

--- a/test/fedora-image/gateway.sh
+++ b/test/fedora-image/gateway.sh
@@ -59,46 +59,60 @@ etcd:
     keyttl: 1
     mandatory: false
 
-routes:
-    service1:
-        source: ["gateway1:2022", "gateway2:2022"]
-        dest: ["server1", "server2"]
-        route_select: ordered
-        mode: sticky
-        etcd_keyttl: 0
-    service2:
-        source: ["gateway1:2023"]
-        dest: ["server1"]
-    service3:
-        source: ["gateway1:2024"]
-        dest: ["server2"]
-        environment:
-            XMODIFIERS: serviceEnv_{user}
-    sftp:
-        source: ["gateway2:2023"]
-        dest: ["server1"]
-        force_command: "/usr/libexec/openssh/sftp-server"
-        command_must_match: true
-    default:
-        dest: ["server3"]
+service: default
+dest: ["server3"]
 
-groups:
-    - user1,unknowngroup:
-        routes:
-            service2:
-                source: ["gateway1:2023"]
-                dest: ["server2"]
-
-users:
-    - unknownuser,user2:
-        environment:
-            XMODIFIERS: globalUserEnv_{user}
-        routes:
-            service3:
-                source: ["gateway1:2024"]
-                dest: ["server1"]
-                environment:
-                    XMODIFIERS: serviceUserEnv_{user}
+overrides:
+    - match:
+          - source: "gateway1:2022"
+          - source: "gateway2:2022"
+      service: service1
+      dest: ["server1", "server2"]
+      route_select: ordered
+      mode: sticky
+      etcd_keyttl: 0
+    - match:
+          - source: "gateway1:2023"
+      service: service2
+      dest: ["server1"]
+    - match:
+          - source: "gateway1:2024"
+      service: service3
+      dest: ["server2"]
+      environment:
+          XMODIFIERS: serviceEnv_{user}
+    - match:
+          - source: "gateway2:2023"
+      service: sftp
+      dest: ["server1"]
+      force_command: "/usr/libexec/openssh/sftp-server"
+      command_must_match: true
+    - match:
+          - source: "gateway1:2023"
+            group: user1
+          - source: "gateway1:2023"
+            group: unknowngroup
+          - source: "gateway1:2023"
+            user: unknownuser
+      service: service2
+      dest: ["server2"]
+    - match:
+          - group: unknowngroup
+          - user: unknownuser
+          - user: user2
+      environment:
+          XMODIFIERS: globalUserEnv_{user}
+    - match:
+          - source: "gateway1:2024"
+            group: unknowngroup
+          - source: "gateway1:2024"
+            user: unknownuser
+          - source: "gateway1:2024"
+            user: user2
+      service: service3
+      dest: ["server1"]
+      environment:
+          XMODIFIERS: serviceUserEnv_{user}
 EOF
 
 exec "$@"

--- a/test/fedora-image/gateway.sh
+++ b/test/fedora-image/gateway.sh
@@ -64,51 +64,45 @@ dest: ["server3"]
 
 overrides:
     - match:
-          - source: "gateway1:2022"
-          - source: "gateway2:2022"
+          - sources: ["gateway1:2022", "gateway2:2022"]
       service: service1
       dest: ["server1", "server2"]
       route_select: ordered
       mode: sticky
       etcd_keyttl: 0
     - match:
-          - source: "gateway1:2023"
+          - sources: ["gateway1:2023"]
       service: service2
       dest: ["server1"]
     - match:
-          - source: "gateway1:2024"
+          - sources: ["gateway1:2024"]
       service: service3
       dest: ["server2"]
       environment:
           XMODIFIERS: serviceEnv_{user}
     - match:
-          - source: "gateway2:2023"
+          - sources: ["gateway2:2023"]
       service: sftp
       dest: ["server1"]
       force_command: "/usr/libexec/openssh/sftp-server"
       command_must_match: true
     - match:
-          - source: "gateway1:2023"
-            group: user1
-          - source: "gateway1:2023"
-            group: unknowngroup
-          - source: "gateway1:2023"
-            user: unknownuser
+          - sources: ["gateway1:2023"]
+            groups: [user1, unknowngroup]
+          - sources: ["gateway1:2023"]
+            users: [unknownuser]
       service: service2
       dest: ["server2"]
     - match:
-          - group: unknowngroup
-          - user: unknownuser
-          - user: user2
+          - groups: [unknowngroup]
+          - users: [unknownuser, user2]
       environment:
           XMODIFIERS: globalUserEnv_{user}
     - match:
-          - source: "gateway1:2024"
-            group: unknowngroup
-          - source: "gateway1:2024"
-            user: unknownuser
-          - source: "gateway1:2024"
-            user: user2
+          - sources: ["gateway1:2024"]
+            groups: [unknowngroup]
+          - sources: ["gateway1:2024"]
+            users: [unknownuser, user2]
       service: service3
       dest: ["server1"]
       environment:


### PR DESCRIPTION
This is a big breaking change in `sshproxy.yaml`
- it now allows to override any key!
- the route system, users and groups override systems are all replaced by a new overrides system, which is more flexible and upgradeable (we can add new filters to match against).
- matches can be made against user, group and source (host:port of the listening sshd)
- multiple overrides can match, they are applied from top to bottom (meaning the last one will have precedence if a same key is overriden multiple times)

Migration example:
```
routes:
  service1:
    source: [host2]
    dest: [host3]
  default:
    dest: [host1]
users:
  - foo:
      debug: true
```
becomes:
```
service: default
dest: [host1]
overrides:
  - match:
      - source: host2
    service: service1
    dest: [host3]
  - match:
      - user: foo
    debug: true
```

A more complex config can now be done, like this:
```
overrides:
  - match:
      - source: host1
        group: foo
      - group: bar
        group: baz
    debug: true
```
Meaning "(if source is host1 AND user has group foo) OR (if user has group bar AND user has group baz) then debug is set to true"