### PR TITLE
add blocking_command option to config

### DIFF
--- a/cmd/sshproxy/sshproxy.go
+++ b/cmd/sshproxy/sshproxy.go
@@ -374,6 +374,21 @@ func mainExitCode() int {
 		}()
 	}
 
+	// launch blocking command
+	if config.BlockingCommand != "" {
+		args := strings.Fields(config.BlockingCommand)
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		rc, err := runCommand(cmd, false)
+		if err != nil {
+			log.Errorf("error running blocking command: %s", err)
+		}
+		if rc != 0 {
+			return rc
+		}
+	}
+
 	// launch background command
 	if config.BgCommand != "" {
 		wg.Add(1)

--- a/config/sshproxy.yaml
+++ b/config/sshproxy.yaml
@@ -79,6 +79,12 @@
 #    command: "sftp"
 #    disable_dump: true
 
+# A command can be launched before the bg_command and before connecting to the
+# destination. The standard and error outputs are displayed to the user. If the
+# return code of the blocking command is not 0, sshproxy will abort the
+# session.
+#blocking_command: ""
+
 # A command can be launched in the background for the session duration.
 # The standard and error outputs are only logged in debug mode.
 #bg_command: ""

--- a/doc/sshproxy.yaml.txt
+++ b/doc/sshproxy.yaml.txt
@@ -47,6 +47,13 @@ The following keys can be defined:
 	precisely, when all backends are either down or disabled in etcd).
 	This message can be multiline. It is empty by default.
 
+*blocking_command*::
+	A string specifying a command which will be launched before the
+	bg_command and before connecting to the destination. The standard and
+	error outputs are displayed to the user. If the return code of the
+	blocking command is not 0, sshproxy will abort the session. It is
+	empty by default.
+
 *bg_command*::
 	a string specifying a command which will be launched in the background
 	for the session duration. Its standard and error outputs are only

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -53,6 +53,7 @@ type Config struct {
 	Etcd                  etcdConfig
 	EtcdStatsInterval     Duration `yaml:"etcd_stats_interval"`
 	LogStatsInterval      Duration `yaml:"log_stats_interval"`
+	BlockingCommand       string   `yaml:"blocking_command"`
 	BgCommand             string   `yaml:"bg_command"`
 	SSH                   sshConfig
 	TranslateCommands     map[string]*TranslateCommandConfig `yaml:"translate_commands"`
@@ -110,6 +111,7 @@ type subConfig struct {
 	Etcd                  interface{}
 	EtcdStatsInterval     interface{} `yaml:"etcd_stats_interval"`
 	LogStatsInterval      interface{} `yaml:"log_stats_interval"`
+	BlockingCommand       interface{} `yaml:"blocking_command"`
 	BgCommand             interface{} `yaml:"bg_command"`
 	SSH                   interface{}
 	TranslateCommands     map[string]*TranslateCommandConfig `yaml:"translate_commands"`
@@ -138,6 +140,7 @@ func PrintConfig(config *Config, groups map[string]bool) []string {
 	output = append(output, fmt.Sprintf("config.etcd = %+v", config.Etcd))
 	output = append(output, fmt.Sprintf("config.etcd_stats_interval = %s", config.EtcdStatsInterval.Duration()))
 	output = append(output, fmt.Sprintf("config.log_stats_interval = %s", config.LogStatsInterval.Duration()))
+	output = append(output, fmt.Sprintf("config.blocking_command = %s", config.BlockingCommand))
 	output = append(output, fmt.Sprintf("config.bg_command = %s", config.BgCommand))
 	output = append(output, fmt.Sprintf("config.ssh = %+v", config.SSH))
 	for k, v := range config.TranslateCommands {
@@ -210,6 +213,10 @@ func parseSubConfig(config *Config, subconfig *subConfig) error {
 		if err != nil {
 			return err
 		}
+	}
+
+	if subconfig.BlockingCommand != nil {
+		config.BlockingCommand = subconfig.BlockingCommand.(string)
 	}
 
 	if subconfig.BgCommand != nil {


### PR DESCRIPTION
Can be useful on some use cases. The command can do whatever you need. It is executed before bg_command and ssh to the login node. If its return code is not 0, the sshproxy aborts the session.